### PR TITLE
Floating label’s left edge aligns to the editing rect’s left edge

### DIFF
--- a/B68UIFloatLabelTextField/B68UIFloatLabelTextField.swift
+++ b/B68UIFloatLabelTextField/B68UIFloatLabelTextField.swift
@@ -160,6 +160,10 @@ open class B68UIFloatLabelTextField: UITextField {
   //MARK: - Drawing & Animations
   override open func layoutSubviews() {
     super.layoutSubviews()
+    
+    // Before starting any animation, make sure the left edge of the floatingLabel is aligned with the left edge of the editingRect
+    floatingLabel.frame.origin.x = editingRect(forBounds: bounds).minX
+    
     if (isFirstResponder && !hasText) {
       hideFloatingLabel()
     } else if(hasText) {
@@ -170,7 +174,8 @@ open class B68UIFloatLabelTextField: UITextField {
   func showFloatingLabelWithAnimation(_ isAnimated : Bool)
   {
     let fl_frame = CGRect(
-      x: horizontalPadding,
+      // Have the new frame after animation be the left edge of the editingRect
+      x:  editingRect(forBounds: bounds).minX,
       y: 0,
       width: self.floatingLabel.frame.width,
       height: self.floatingLabel.frame.height
@@ -189,7 +194,8 @@ open class B68UIFloatLabelTextField: UITextField {
   
   func hideFloatingLabel () {
     let fl_frame = CGRect(
-      x: horizontalPadding,
+      // Have the new frame after animation be the left edge of the editingRect
+      x:  editingRect(forBounds: bounds).minX,
       y: verticalPadding,
       width: self.floatingLabel.frame.width,
       height: self.floatingLabel.frame.height


### PR DESCRIPTION
I needed to be able to add a view in the leftView property of the B68FloatingLabelTextField. Unfortunately, the floatingLabel was not positioning itself where I expected.

The changes below always align the left edge of the floatingLabel to the left edge of the text field's editing rect. If there is no leftView added, there is no change from the standard behavior. A small amount of testing indicates that adjusting the horizontalPadding still works as expected.

(This is my first pull request on an open source project. If I am doing something that does not follow etiquette, please let me know.)